### PR TITLE
Add BitStringLiteral and related types

### DIFF
--- a/src/Language/VHDL/Pretty.hs
+++ b/src/Language/VHDL/Pretty.hs
@@ -1060,6 +1060,9 @@ instance Pretty SubprogramSpecification where
         Just True  -> text "PURE"
         Just False -> text "IMPURE"
 
+instance Pretty SubprogramDeclaration where
+  pp (SubprogramDeclaration s) = pp s <+> semi
+
 --instance Pretty SubprogramStatementPart where pp = undefined
 
 instance Pretty SubtypeDeclaration where

--- a/src/Language/VHDL/Pretty.hs
+++ b/src/Language/VHDL/Pretty.hs
@@ -122,7 +122,10 @@ instance Pretty AttributeSpecification where
     <+> text "OF" <+> pp s
     <+> text "IS" <+> pp e <+> semi
 
-instance Pretty BaseSpecifier where pp = error "missing: BaseSpecifier" -- todo
+instance Pretty BaseSpecifier where
+  pp BSOctal = char 'o'
+  pp BSBinary = char 'b'
+  pp BSHexadecimal = char 'x'
 
 instance Pretty BaseUnitDeclaration where pp = error "missing: BaseUnitDeclaration" -- todo
 
@@ -139,9 +142,11 @@ instance Pretty BindingIndication where
   pp (BindingIndication e g p) =
     vcat [condR (text "USE") e, cond id g, cond id p]
 
-instance Pretty BitStringLiteral where pp = error "missing: BitStringLiteral" -- todo
+instance Pretty BitStringLiteral where
+  pp (BitStringLiteral bs bv) = pp bs <> doubleQuotes (pp bv)
 
-instance Pretty BitValue where pp = error "missing: BitValue" -- todo
+instance Pretty BitValue where
+  pp (BitValue eds) = pp eds
 
 instance Pretty BlockConfiguration where
   pp (BlockConfiguration s u c) =
@@ -483,7 +488,8 @@ instance Pretty Expression where
   pp (ENor r rs)  = pp r <+> condL (text "NOR")  rs
   pp (EXnor rs)   = textSep "XNOR" $ map pp rs
 
-instance Pretty ExtendedDigit where pp = error "missing: ExtendedDigit" -- todo
+instance Pretty ExtendedDigit where
+  pp (ExtendedDigit ed) = char ed
 
 instance Pretty ExtendedIdentifier where pp = error "missing: ExtendedIdentifier" -- todo
 

--- a/src/Language/VHDL/Pretty.hs
+++ b/src/Language/VHDL/Pretty.hs
@@ -167,8 +167,8 @@ instance Pretty BlockDeclarativeItem where
   pp (BDIAlias a)       = pp a
   pp (BDIComp c)        = pp c
   pp (BDIAttrDecl a)    = pp a
-  pp (BDIAttrSepc a)    = pp a
-  pp (BDIConfigSepc c)  = pp c
+  pp (BDIAttrSpec a)    = pp a
+  pp (BDIConfigSpec c)  = pp c
   pp (BDIDisconSpec d)  = pp d
   pp (BDIUseClause u)   = pp u
   pp (BDIGroupTemp g)   = pp g

--- a/src/Language/VHDL/Pretty.hs
+++ b/src/Language/VHDL/Pretty.hs
@@ -544,7 +544,7 @@ instance Pretty GenerateStatement where
   pp (GenerateStatement l g d s) =
     pp l <+> colon `hangs` vcat
       [ pp g <+> text "GENERATE"
-      , cond indent d
+      , maybe empty (indent . vcat . fmap pp) d
       , cond (const $ text "BEGIN") d
       , indent $ vcat $ fmap pp s
       , text "END GENERATE" <+> pp l <+> semi

--- a/src/Language/VHDL/Pretty.hs
+++ b/src/Language/VHDL/Pretty.hs
@@ -146,7 +146,7 @@ instance Pretty BitStringLiteral where
   pp (BitStringLiteral bs bv) = pp bs <> doubleQuotes (pp bv)
 
 instance Pretty BitValue where
-  pp (BitValue eds) = text . fmap (\(ExtendedDigit c) -> c) $ eds
+  pp (BitValue eds) = text eds
 
 instance Pretty BlockConfiguration where
   pp (BlockConfiguration s u c) =
@@ -487,9 +487,6 @@ instance Pretty Expression where
   pp (ENand r rs) = pp r <+> condL (text "NAND") rs
   pp (ENor r rs)  = pp r <+> condL (text "NOR")  rs
   pp (EXnor rs)   = textSep "XNOR" $ map pp rs
-
-instance Pretty ExtendedDigit where
-  pp (ExtendedDigit ed) = char ed
 
 instance Pretty ExtendedIdentifier where pp = error "missing: ExtendedIdentifier" -- todo
 

--- a/src/Language/VHDL/Pretty.hs
+++ b/src/Language/VHDL/Pretty.hs
@@ -551,8 +551,8 @@ instance Pretty GenerateStatement where
       ]
 
 instance Pretty GenerationScheme where
-  pp (GSFor p) = pp p
-  pp (GSIf c)  = pp c
+  pp (GSFor p) = text "FOR" <+> pp p
+  pp (GSIf c)  = text "IF" <+> pp c
 
 instance Pretty GenericClause where
   pp (GenericClause ls) = text "GENERIC" <+> parens (pp ls) <+> semi

--- a/src/Language/VHDL/Pretty.hs
+++ b/src/Language/VHDL/Pretty.hs
@@ -146,7 +146,7 @@ instance Pretty BitStringLiteral where
   pp (BitStringLiteral bs bv) = pp bs <> doubleQuotes (pp bv)
 
 instance Pretty BitValue where
-  pp (BitValue eds) = pp eds
+  pp (BitValue eds) = text . fmap (\(ExtendedDigit c) -> c) $ eds
 
 instance Pretty BlockConfiguration where
   pp (BlockConfiguration s u c) =

--- a/src/Language/VHDL/Pretty.hs
+++ b/src/Language/VHDL/Pretty.hs
@@ -470,7 +470,7 @@ instance Pretty EnumerationLiteral where
   pp (EChar c) = pp c
 
 instance Pretty EnumerationTypeDefinition where
-  pp (EnumerationTypeDefinition es) = commaSep $ fmap pp es
+  pp (EnumerationTypeDefinition es) = parens . commaSep . fmap pp $ es
 
 instance Pretty ExitStatement where
   pp (ExitStatement l b c) =

--- a/src/Language/VHDL/Syntax.hs
+++ b/src/Language/VHDL/Syntax.hs
@@ -2826,13 +2826,16 @@ data BasicGraphicCharacter = BasicGraphicCharacter
 data BasicIdentifier = BasicIdentifier
   deriving (Eq, Show)
 
-data BitStringLiteral = BitStringLiteral
+data BitStringLiteral = BitStringLiteral {
+    bsl_base_specifier :: BaseSpecifier
+  , bsl_bit_value :: BitValue
+  }
   deriving (Eq, Show)
 
-data BitValue = BitValue
+data BitValue = BitValue [ExtendedDigit]
   deriving (Eq, Show)
 
-data ExtendedDigit = ExtendedDigit
+data ExtendedDigit = ExtendedDigit Char
   deriving (Eq, Show)
 
 data ExtendedIdentifier = ExtendedIdentifier

--- a/src/Language/VHDL/Syntax.hs
+++ b/src/Language/VHDL/Syntax.hs
@@ -2792,6 +2792,29 @@ type Base = Integer
 type BasedInteger = Integer
 
 --------------------------------------------------------------------------------
+-- *** 13.7 Bit string literals
+
+{-
+    bit_string_literal ::= base_specifier "[ bit_value ]"
+
+    bit_value ::= extended_digit { [ underline ] extended_digit }
+
+    base_specifier ::= B | O | X
+-}
+
+data BitStringLiteral = BitStringLiteral {
+    bsl_base_specifier :: BaseSpecifier
+  , bsl_bit_value :: BitValue
+  }
+  deriving (Eq, Show)
+
+data BitValue = BitValue [ExtendedDigit]
+  deriving (Eq, Show)
+
+data ExtendedDigit = ExtendedDigit Char
+  deriving (Eq, Show)
+
+--------------------------------------------------------------------------------
 --
 --                                  - ToDo -
 --
@@ -2824,18 +2847,6 @@ data BasicGraphicCharacter = BasicGraphicCharacter
   deriving (Eq, Show)
 
 data BasicIdentifier = BasicIdentifier
-  deriving (Eq, Show)
-
-data BitStringLiteral = BitStringLiteral {
-    bsl_base_specifier :: BaseSpecifier
-  , bsl_bit_value :: BitValue
-  }
-  deriving (Eq, Show)
-
-data BitValue = BitValue [ExtendedDigit]
-  deriving (Eq, Show)
-
-data ExtendedDigit = ExtendedDigit Char
   deriving (Eq, Show)
 
 data ExtendedIdentifier = ExtendedIdentifier

--- a/src/Language/VHDL/Syntax.hs
+++ b/src/Language/VHDL/Syntax.hs
@@ -2791,6 +2791,8 @@ type Base = Integer
 
 type BasedInteger = Integer
 
+type ExtendedDigit = Char
+
 --------------------------------------------------------------------------------
 -- *** 13.7 Bit string literals
 
@@ -2811,7 +2813,10 @@ data BitStringLiteral = BitStringLiteral {
 data BitValue = BitValue [ExtendedDigit]
   deriving (Eq, Show)
 
-data ExtendedDigit = ExtendedDigit Char
+data BaseSpecifier =
+    BSOctal
+  | BSBinary
+  | BSHexadecimal
   deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
@@ -2830,12 +2835,6 @@ data StringLiteral    = SLit String
   deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
-
-data BaseSpecifier =
-    BSOctal
-  | BSBinary
-  | BSHexadecimal
-  deriving (Eq, Show)
 
 data BaseUnitDeclaration = BaseUnitDeclaration
   deriving (Eq, Show)

--- a/src/Language/VHDL/Syntax.hs
+++ b/src/Language/VHDL/Syntax.hs
@@ -2573,7 +2573,7 @@ data InstantiatedUnit =
 data GenerateStatement = GenerateStatement {
     gens_label                  :: Label
   , gens_generation_scheme      :: GenerationScheme
-  , gens_block_declarative_item :: Maybe (BlockDeclarativeItem)
+  , gens_block_declarative_item :: Maybe [BlockDeclarativeItem]
   , gens_concurrent_statement   :: [ConcurrentStatement]
   }
   deriving (Eq, Show)

--- a/src/Language/VHDL/Syntax.hs
+++ b/src/Language/VHDL/Syntax.hs
@@ -531,7 +531,7 @@ data PackageDeclarativeItem =
 -- * 2.6 Package bodies
 {-
     package_body ::=
-      PACKAGE  package_simple_name IS
+      PACKAGE BODY package_simple_name IS
         package_body_declarative_part
       END [ PACKAGE BODY ] [ package_simple_name ] ;
 

--- a/src/Language/VHDL/Syntax.hs
+++ b/src/Language/VHDL/Syntax.hs
@@ -333,7 +333,8 @@ data ComponentConfiguration = ComponentConfiguration {
     operator_symbol ::= string_literal
 -}
 
-type SubprogramDeclaration   = SubprogramSpecification
+newtype SubprogramDeclaration = SubprogramDeclaration SubprogramSpecification
+  deriving (Eq, Show)
 
 data SubprogramSpecification =
     SubprogramProcedure {

--- a/src/Language/VHDL/Syntax.hs
+++ b/src/Language/VHDL/Syntax.hs
@@ -2808,7 +2808,10 @@ data StringLiteral    = SLit String
 
 --------------------------------------------------------------------------------
 
-data BaseSpecifier = BaseSpecifier
+data BaseSpecifier =
+    BSOctal
+  | BSBinary
+  | BSHexadecimal
   deriving (Eq, Show)
 
 data BaseUnitDeclaration = BaseUnitDeclaration

--- a/src/Language/VHDL/Syntax.hs
+++ b/src/Language/VHDL/Syntax.hs
@@ -192,8 +192,8 @@ data BlockDeclarativeItem =
   | BDIAlias        AliasDeclaration
   | BDIComp         ComponentDeclaration
   | BDIAttrDecl     AttributeDeclaration
-  | BDIAttrSepc     AttributeSpecification
-  | BDIConfigSepc   ConfigurationSpecification
+  | BDIAttrSpec     AttributeSpecification
+  | BDIConfigSpec   ConfigurationSpecification
   | BDIDisconSpec   DisconnectionSpecification
   | BDIUseClause    UseClause
   | BDIGroupTemp    GroupTemplateDeclaration


### PR DESCRIPTION
This adds definitions and pretty printers for BitStringLiteral and related types (BitValue, BaseSpecifier and ExtendedDigit). I chose to make ExtendedDigit a type synonym for char since that seemed sensible. The representation of those simple tokens (all the Basic/Extended Character/Identifier/Digit types) seems to be an open issue, since exactly representing them as Haskell types imposes an organizational and structural overhead (essentially since String = [Char] no longer holds).
I've also done a few drive-by fixes that I can factor out of this PR if you'd like. Perhaps most interesting is GenerateStatement which didn't allow more than one BlockDeclarativeItem.